### PR TITLE
Per day hour wrap

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 ipcrm
+jbcraig

--- a/README.markdown
+++ b/README.markdown
@@ -21,11 +21,19 @@ This module is actually made up of just one function, change_window.  All the fu
 *IMPORTANT* Remember that if your _within_ the change window the value returned is _true_, otherwise it returns _false_.
 
 ## Usage
+change_window( $tz, $window_wday, $window_time, $window_type, [$time])
+
 Where:
 `$tz` is the timezone offset you want used when the current timestamp is generated.(this example is for EST)
-`$window_wday` is a hash where start is the first weekday in your window and end is the last weekday - expressed as weekday names or 0-6.  You can specify the same day if you like.
-`$window_time` is a hash where the start key is a timestamp (HH:MM), and end sets the end hour and minute.
-`$window_type` accepts to values: per_day or window.  `per_day` tells change_window that the hours specified are valid on each day specified.  For example if you set days 0-3 and start 20:00, end 23:00 - then Sunday through Wednesday from 8PM to 11PM this function will return true.  `window` (or actually any value but per_day) tells change_window to treat the days and times as a continuous change window spanning from start day/start time through end day/end time.
+
+`$window_wday` is a hash where start is the first weekday in your window and end is the last weekday - expressed as weekday names or 0-6.  You can specify the same day if you like and you may wrap the weekend (i.e friday .. monday).
+
+`$window_time` is a hash where the start key is a timestamp (HH:MM), and end sets the end hour and minute. You may wrap the midnight hour (i.e. 22:00 .. 02:00).
+
+`$window_type` accepts to values: per_day or window.  
+* `per_day` tells change_window that the hours specified are valid on each day specified.  For example if you set days 0-3 and start 20:00, end 23:00 - then Sunday through Wednesday from 8PM to 11PM this function will return true. For wrapped hours you receive start to midnight on the first day and midnight to end on the last day.
+* `window` tells change_window to treat the days and times as a continuous change window spanning from start day/start time through end day/end time.
+*  `$time` is an optional parameter that lets you specify the time to test as an array.  This array is passed to the Time.new() object to set the time under test.  This array should take the form of [ YYYY, MM, DD, HH, MM] and will apply the timezone specified.
 
 ```puppet
 $tz = "-05:00"

--- a/lib/puppet/parser/functions/change_window.rb
+++ b/lib/puppet/parser/functions/change_window.rb
@@ -10,7 +10,6 @@ module Puppet::Parser::Functions
       def change_window_time_is_within(s,e,c)
         # Calculate by minutes of the week 0 ... 86400
         test = ((s[0].to_i*60+s[1].to_i)..(e[0].to_i*60+e[1])).cover?(c[0]*60+c[1])
-        puts "change_window_time_is_within( #{(s[0].to_i*60+s[1].to_i)},#{(e[0].to_i*60+e[1])}, #{(c[0]*60+c[1])}) == #{test}"
         return test
       end
     end
@@ -20,7 +19,6 @@ module Puppet::Parser::Functions
     # args[2] Hash, window_wday
     # args[3] Hash, window_time
     # args[4] String, Point-in-time to test (optional)
-    #puts "args = #{args}"
 
     # Validate Arguments are all present
     raise Puppet::ParseError, "Invalid argument count, got #{args.length} expected 4 or 5" unless (4..5).cover?(args.length)
@@ -120,7 +118,6 @@ module Puppet::Parser::Functions
         raise Puppet::ParseError, "Could not convert time array into valid Time.new object, received #{args[4].to_a}"
       end
     end
-    #puts "t = #{t.to_s}"
 
     # Build array of valid_days
     if window_wday_int['start'] > window_wday_int['end']
@@ -130,18 +127,14 @@ module Puppet::Parser::Functions
       # Within-EOW 1,4 = 1,2,3,4
       valid_days = (window_wday_int['start']..window_wday_int['end']).to_a.uniq
     end
-    puts "valid_days are #{valid_days.to_s}"
 
     # Determine if today is within the valid days for the change window
-    puts "Start decision tree"
     if valid_days.include?(t.wday)
 
       # IF this is the first day of the window
       if t.wday == window_wday_int['start'] and valid_days.length > 1
-        puts "start day"
         # If window type or per_day with midnight wrap
         if window_type == 'window' or (window_type == 'per_day' and window_time_str['start'] > window_time_str['end'])
-          puts "adjust end_time"
           # IF we are within <start time> and 23:59 return true
           window_time['end'] = [23,59]
         end
@@ -149,11 +142,9 @@ module Puppet::Parser::Functions
 
       # If this is the last day of the window
       elsif t.wday == window_wday_int['end'] and valid_days.length > 1
-        puts "end day"
 
         # If window type or per_day with midnight wrap
         if window_type == 'window' or (window_type == 'per_day' and window_time_str['start'] > window_time_str['end'])
-          puts "adjust start_time"
           #If we are within 00:00 and end
           window_time['start'] = [0, 0]
         end
@@ -161,24 +152,20 @@ module Puppet::Parser::Functions
 
       # If 1 day window type or per_day wo/ midnight wrap
       elsif (valid_days.length == 1 and window_type == 'window') or window_type == 'per_day'
-        puts "oneday or simple start/end"
         change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
 
 
       # midweek per_day
       elsif window_type == 'per_day'
-        puts "midweek per_day type"
         change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
 
       # Fall through matches window type and between window start/end
       else
-        puts "midweek window type"
         true.to_s
       end
 
     # Your not within the valid_days
     else
-      puts "not valid day"
       false.to_s
     end
   end

--- a/lib/puppet/parser/functions/change_window.rb
+++ b/lib/puppet/parser/functions/change_window.rb
@@ -8,25 +8,10 @@ module Puppet::Parser::Functions
   ) do |args|
     class << self
       def change_window_time_is_within(s,e,c)
-        #Hours
-        if (s[0].to_i .. e[0].to_i).cover?(c[0].to_i)
-
-          # Mins
-          ## If mins are identical we are only comparing hours
-          if s[1] != e[1]
-
-            ## Check if our current minutes is within the change window range
-            if (s[1].to_i .. e[1].to_i).cover?(c[1].to_i)
-              return true
-            end
-
-          ## Since we are only comparing hours and have made it here
-          ## we are wihin the change window
-          else
-            return true
-          end
-        end
-          return false
+        # Calculate by minutes of the week 0 ... 86400
+        test = ((s[0].to_i*60+s[1].to_i)..(e[0].to_i*60+e[1])).cover?(c[0]*60+c[1])
+        puts "change_window_time_is_within( #{(s[0].to_i*60+s[1].to_i)},#{(e[0].to_i*60+e[1])}, #{(c[0]*60+c[1])}) == #{test}"
+        return test
       end
     end
 
@@ -34,17 +19,20 @@ module Puppet::Parser::Functions
     # args[1] Window Type - per_day or window(default)
     # args[2] Hash, window_wday
     # args[3] Hash, window_time
+    # args[4] String, Point-in-time to test (optional)
+    #puts "args = #{args}"
 
     # Validate Arguments are all present
-    if args.length != 4
-      raise Puppet::ParseError, "Invalid argument count, got #{args.length} expected 4"
-    end
+    raise Puppet::ParseError, "Invalid argument count, got #{args.length} expected 4 or 5" unless (4..5).cover?(args.length)
 
     # Validate Args are correct type
     raise Puppet::ParseError, "TimeZone must be a string!"    unless args[0].is_a? String
     raise Puppet::ParseError, "Window type must be a string!" unless args[1].is_a? String
     raise Puppet::ParseError, "Window_wday must be a hash!"   unless args[2].is_a? Hash
     raise Puppet::ParseError, "Window_time must be a hash!"   unless args[3].is_a? Hash
+    if( args.length == 5)
+      raise Puppet::ParseError, "Point-in-time must be an array!" unless args[4].is_a? Array
+    end
 
     # Set Timezone for other timestamp
     timezone = args[0]
@@ -117,55 +105,80 @@ module Puppet::Parser::Functions
     start_time = args[3]['start'].split(':').map(&:to_i)
     end_time   = args[3]['end'].split(':').map(&:to_i)
     window_time = {'start' => start_time, 'end' => end_time }
+    window_time_str = {'start' => sprintf('%02d:%02d', start_time[0], start_time[1]),
+      'end' => sprintf('%02d:%02d',end_time[0],end_time[1])}
 
     # Get Time (this will use localtime)
-    t = Time.now.getlocal(timezone)
-
-
-    if window_wday_int['end'] == 0 and window_wday_int['start'] != 0
-      valid_days = (window_wday_int['start']..window_wday_int['start']+(6-window_wday_int['start'])).to_a.push(0).uniq
+    if args.length != 5
+      t = Time.now.getlocal(timezone)
     else
+      raise Puppet::ParseError, "Invalid key for time expected 5 values and received #{args[4].length}" unless args[4].length == 5
+      begin
+        t = Time.new( *args[4], 0, timezone)
+      rescue Exception
+        # Catch exception and rebrand as parse error
+        raise Puppet::ParseError, "Could not convert time array into valid Time.new object, received #{args[4].to_a}"
+      end
+    end
+    #puts "t = #{t.to_s}"
+
+    # Build array of valid_days
+    if window_wday_int['start'] > window_wday_int['end']
+      # EOW-Wrap 4,1 = 4,5,6,0,1
+      valid_days = (window_wday_int['start']..6).to_a + (0..window_wday_int['end']).to_a.uniq
+    else
+      # Within-EOW 1,4 = 1,2,3,4
       valid_days = (window_wday_int['start']..window_wday_int['end']).to_a.uniq
     end
+    puts "valid_days are #{valid_days.to_s}"
 
     # Determine if today is within the valid days for the change window
+    puts "Start decision tree"
     if valid_days.include?(t.wday)
 
       # IF this is the first day of the window
-      # And the window is multiple days
-      # And the window is continuous (not per_day)
-      # adjust the end time to be 23:59 (ie the last possible minute of the day)
-      if t.wday == window_wday_int['start'] and valid_days.length > 1 and window_type != 'per_day'
-        window_time['end'] = ['23','59']
-        # IF we are within <start time> and 23:59 return true
+      if t.wday == window_wday_int['start'] and valid_days.length > 1
+        puts "start day"
+        # If window type or per_day with midnight wrap
+        if window_type == 'window' or (window_type == 'per_day' and window_time_str['start'] > window_time_str['end'])
+          puts "adjust end_time"
+          # IF we are within <start time> and 23:59 return true
+          window_time['end'] = [23,59]
+        end
+        change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
+
+      # If this is the last day of the window
+      elsif t.wday == window_wday_int['end'] and valid_days.length > 1
+        puts "end day"
+
+        # If window type or per_day with midnight wrap
+        if window_type == 'window' or (window_type == 'per_day' and window_time_str['start'] > window_time_str['end'])
+          puts "adjust start_time"
+          #If we are within 00:00 and end
+          window_time['start'] = [0, 0]
+        end
+        change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
+
+      # If 1 day window type or per_day wo/ midnight wrap
+      elsif (valid_days.length == 1 and window_type == 'window') or window_type == 'per_day'
+        puts "oneday or simple start/end"
         change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
 
 
-      # IF this is the last day of the window, adjust to compare from 00:00 start time (ie first minute possible)
-      # And the window is multiple days
-      # And the window is continuous (not per_day)
-      elsif t.wday == window_wday_int['end'] and valid_days.length > 1 and window_type != 'per_day'
-        window_time['start'] = ['00','00']
-        # IF we are within 00:00 and <end time> return true
-        change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
-
-      # If you've set window as your window type check and BUT thier is only 1 valid days
-      elsif valid_days.length == 1 and window_type != 'per_day'
-        change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
-
-      # If you've set per_day as your window type check if we are within the correct time
+      # midweek per_day
       elsif window_type == 'per_day'
+        puts "midweek per_day type"
         change_window_time_is_within(window_time['start'],window_time['end'],[t.hour,t.min]) == true ? true.to_s : false.to_s
 
+      # Fall through matches window type and between window start/end
       else
-        # If you've accepted the default window_type this is a continuous change window
-        # Based on the above logic, this isn't the first day of the window, its not the last, but its within the valid_days
-        # for your window.  Meaning, we don't care about time.  Its in your window.  Example: Start is Mon, End is Wed,
-        # today is Tuesday.
+        puts "midweek window type"
         true.to_s
       end
+
     # Your not within the valid_days
     else
+      puts "not valid day"
       false.to_s
     end
   end

--- a/lib/puppet/parser/functions/change_window.rb
+++ b/lib/puppet/parser/functions/change_window.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
   ) do |args|
     class << self
       def change_window_time_is_within(s,e,c)
-        # Calculate by minutes of the week 0 ... 86400
+        # Calculate by minutes of the week 0 ... 1439
         test = ((s[0].to_i*60+s[1].to_i)..(e[0].to_i*60+e[1])).cover?(c[0]*60+c[1])
         return test
       end

--- a/spec/functions/change_window_spec.rb
+++ b/spec/functions/change_window_spec.rb
@@ -1,58 +1,83 @@
 require 'spec_helper'
+tz = "-05:00"
+time  = [2016,1,6,6,15] # 2016-01-06 06:15 (Wed)
+oTime = Time.new( *time, 0, tz)
 
-t = Time.now()
+Puppet::Util::Log.level = :debug
+Puppet::Util::Log.newdestination(:console)
 
-# Build some dynamic dates and times for testing
-test_hour_start = t.hour - 1
-test_hour_end   = t.hour + 1
-test_hour_start = 0 if test_hour_start < 0
-test_hour_end = 23 if test_hour_end > 23
-test_day        = t.wday
-test_wdw_start  = t.wday - 1
-test_wdw_end    = t.wday + 2
-test_wdw_start = 0 if test_wdw_start < 0
-test_wdw_end = 6 if test_wdw_end > 6
-today_d_range = {'start' => test_day,'end' => test_day}
-test_d_range = {'start' => test_wdw_start, 'end' => test_wdw_end }
+# Bad window_time
+fail_wndw_type = 'windows'
+fail_key_day   = {'starts' => '00:00', 'ends' => '23:59'}
+fail_key_time  = {'starts' => '00:00', 'ends' => '23:59'}
 
-fail_d_start = t.wday + 1
-fail_d_start = 6 if fail_d_start > 6
-fail_d_end = t.wday + 2
-fail_d_end = 0 if fail_d_end > 6
-fail_d_range = {'start' => fail_d_start, 'end' => fail_d_end }
-fail_today_range = {'start' => fail_d_start, 'end' => fail_d_start }
-fail_hour_start = t.hour - 5
-fail_hour_end   = fail_hour_start + 1
-fail_hour_start = 0 if fail_hour_start < 0
-fail_hour_end = 23 if fail_hour_end > 23
+# Build some test dates
+pass_wndw_day  = {'start' => 2, 'end' => 4} # Window includes
+fail_wndw_day  = {'start' => 1, 'end' => 2} # Window excludes
+pass_one_day   = {'start' => 3, 'end' => 3} # One day includes
+fail_one_day   = {'start' => 1, 'end' => 1} # One day excludes
+pass_start_day = {'start' => 3, 'end' => 5} # Window starts on t
+pass_end_day   = {'start' => 2, 'end' => 3} # Window ends on t
+pass_wrap_day  = {'start' => 6, 'end' => 4} # Weekend wrap includes
+fail_wrap_day  = {'start' => 6, 'end' => 2} # Weekend wrap excludes
+pass_all_days  = {'start' => 0, 'end' => 6} # All days valid
+pass_string_days = {'start' => 'sUn', 'end' => 'SATurday'}
+fail_string_days = {'start' => 'today', 'end' => 'tommorow'}
 
-# End dynamic dates/times
-
+# Build some test times
+pass_wndw_time       = {'start' => '06:15', 'end' => '06:30'} # Window includes
+fail_wndw_time       = {'start' => '06:00', 'end' => '06:14'} # Window excludes
+pass_wrap_time_start = {'start' => '06:00', 'end' => '05:00'} # Wrap includes start < t
+pass_wrap_time_end   = {'start' => '11:00', 'end' => '06:15'} # Wrap includes end > t
+pass_all_times       = {'start' => '00:00', 'end' => '23:59'} # All times valid
+fail_time_format     = {'start' => '0000', 'end' => '2359'}   # Times missing colon (:)
 
 describe 'change_window' do
+  # Test for parseError's
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError) }
-  it { is_expected.to run.with_params("-05:00",'per_day',{'start'=>0,'end'=>6},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'per_day',{'start'=>'Sunday','end'=>'Saturday'},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>0,'end'=>6},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>'sun','end'=>'sat'},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'per_day',{'start'=>0,'end'=>0},{'start'=>'00:00','end'=>'00:00'}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'per_day',{'start'=>'Sunday','end'=>'sUn'},{'start'=>'00:00','end'=>'00:00'}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>0,'end'=>0},{'start'=>'00:00','end'=>'00:00'}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>'sun','end'=>'Tuesday'},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>'sun','end'=>'Tuesday'},{'start'=>'00:00','end'=>'23:59'}).and_return("true") }
-
-  it { is_expected.to run.with_params("-05:00",'window',{'start'=>'14','end'=>'Tuesday'},{'start'=>'00:00','end'=>'23:59'}).and_raise_error(Puppet::ParseError) }
-
-  it { is_expected.to run.with_params("-05:00",'window',today_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'window',test_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'per_day',today_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'per_day',test_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("true") }
-  it { is_expected.to run.with_params("-05:00",'window',fail_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'window',fail_today_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'window',today_d_range,{'start'=>"#{fail_hour_start}:#{t.min}",'end'=>"#{fail_hour_end}:#{t.min}"}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'per_day',fail_d_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'per_day',fail_today_range,{'start'=>"#{test_hour_start}:#{t.min}",'end'=>"#{test_hour_end}:#{t.min}"}).and_return("false") }
-  it { is_expected.to run.with_params("-05:00",'per_day',today_d_range,{'start'=>"#{fail_hour_start}:#{t.min}",'end'=>"#{fail_hour_end}:#{t.min}"}).and_return("false") }
+  it { is_expected.to run.with_params(tz, fail_wndw_type, pass_all_days, pass_wndw_time).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', pass_all_days,pass_all_times, [2016,1,6,6,60]).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', fail_key_day,pass_all_times, time).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', pass_all_days,fail_key_time).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', pass_all_days,fail_time_format).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', fail_string_days,pass_all_times).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(tz,'window', pass_string_days,pass_all_times, time).and_return("true") }
+  # Test day-of-week (window)
+  it { is_expected.to run.with_params(tz, 'window', pass_wndw_day,  pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', fail_wndw_day,  pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'window', pass_one_day,   pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', fail_one_day,   pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'window', pass_start_day, pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', pass_end_day,   pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', fail_one_day,   pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'window', pass_wrap_day,  pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', fail_wrap_day,  pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'window', pass_start_day, pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', pass_end_day,   pass_all_times, time).and_return("true") }
+  # Test day-of-week (per_day)
+  it { is_expected.to run.with_params(tz, 'per_day', pass_wndw_day,  pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', fail_wndw_day,  pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_one_day,   pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', fail_one_day,   pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_start_day, pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_end_day,   pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', fail_one_day,   pass_all_times, time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_wrap_day,  pass_all_times, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', fail_wrap_day,  pass_all_times, time).and_return("false") }
+  # Test time-of-day (window)
+  it { is_expected.to run.with_params(tz, 'window', pass_one_day,   pass_wndw_time,       time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', pass_one_day,   fail_wndw_time,       time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'window', pass_wndw_day,  pass_wndw_time,       time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', pass_wndw_day,  fail_wndw_time,       time).and_return("true") } # passes because mid-window
+  it { is_expected.to run.with_params(tz, 'window', pass_start_day, pass_wrap_time_start, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'window', pass_end_day,   pass_wrap_time_end,   time).and_return("true") }
+  # Test time-of-day (per_day)
+  it { is_expected.to run.with_params(tz, 'per_day', pass_one_day,   pass_wndw_time,       time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_one_day,   fail_wndw_time,       time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_wndw_day,  pass_wndw_time,       time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_wndw_day,  fail_wndw_time,       time).and_return("false") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_start_day, pass_wrap_time_start, time).and_return("true") }
+  it { is_expected.to run.with_params(tz, 'per_day', pass_end_day,   pass_wrap_time_end,   time).and_return("true") }
 end


### PR DESCRIPTION
- Improved weekend wrap to allow all start/end combinations
- Added ability to span midnight with the time window
- Added optional parameter so time under test may be specified
  - allows one to check if desired time is within window
  - simplifies puppet-rspec test cases
- Revised rspec test cases
  - make use of optional time parameter
  - expanded coverage to more edge cases
- Updated documentation to reflect changes
